### PR TITLE
fix: CLI exit code and --limit validation

### DIFF
--- a/src/notesctl/cli.py
+++ b/src/notesctl/cli.py
@@ -129,6 +129,9 @@ def export(
         for error in result.errors[:10]:
             console.print(f"  {error}")
 
+    if not dry_run and (result.skipped_errors or result.errors):
+        raise typer.Exit(1)
+
 
 @app.command("list-notes")
 def list_notes(

--- a/src/notesctl/cli.py
+++ b/src/notesctl/cli.py
@@ -156,6 +156,7 @@ def list_notes(
             "--limit",
             "-l",
             help="Maximum number of notes to show",
+            min=1,
         ),
     ] = 50,
     db_path: Annotated[

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,39 @@
+"""Tests for the command-line interface."""
+
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from notesctl.cli import app
+from notesctl.exporter import ExportResult
+
+runner = CliRunner()
+
+
+def test_export_exits_nonzero_when_notes_fail(monkeypatch):
+    """Export should fail automation when notes are skipped due to errors."""
+
+    class StubExporter:
+        def __init__(self, db_path: Path | None = None) -> None:
+            self.db_path = db_path
+
+        def export(self, *_args: Any) -> ExportResult:
+            return ExportResult(
+                total_notes=2,
+                exported_notes=1,
+                skipped_encrypted=0,
+                skipped_errors=1,
+                attachments_copied=0,
+                output_path=Path("/tmp/notes-export"),
+                exported_files=[],
+                errors=["boom"],
+            )
+
+    monkeypatch.setattr("notesctl.cli.NotesExporter", StubExporter)
+
+    result = runner.invoke(app, ["export"])
+
+    assert result.exit_code == 1
+    assert "Failed to export 1 notes" in result.output
+    assert "boom" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,3 +37,13 @@ def test_export_exits_nonzero_when_notes_fail(monkeypatch):
     assert result.exit_code == 1
     assert "Failed to export 1 notes" in result.output
     assert "boom" in result.output
+
+
+def test_list_notes_rejects_negative_limit():
+    """Negative limits should fail CLI validation before rendering notes."""
+    result = runner.invoke(app, ["list-notes", "--limit", "-1"])
+
+    assert result.exit_code != 0
+    assert "Invalid value" in result.output
+    assert "Showing -1" not in result.output
+    assert "Notes (" not in result.output


### PR DESCRIPTION
Two CLI bug fixes surfaced by clawpatch review.

## Changes

- **Export exits non-zero on partial failure** — when `export` skips notes due to errors, the command now raises `typer.Exit(1)` for non-dry-run exports. Previously it returned exit code 0, letting backup/automation treat an incomplete export as successful.
- **`list-notes --limit` rejects negative values** — the option is constrained with `min=1`. A negative limit previously fed `notes[:limit]`, hiding the last N notes and printing a misleading "Showing -1 of N notes" count.

Each fix includes a regression test in `tests/test_cli.py`.

## Validation

- `ruff check src tests` — pass
- `ty check` — pass
- `pytest` — 37 passed